### PR TITLE
Fixed bug that prevented to use center crop

### DIFF
--- a/diffusion_policy/model/vision/multi_image_obs_encoder.py
+++ b/diffusion_policy/model/vision/multi_image_obs_encoder.py
@@ -98,7 +98,7 @@ class MultiImageObsEncoder(ModuleAttrMixin):
                             pos_enc=False
                         )
                     else:
-                        this_normalizer = torchvision.transforms.CenterCrop(
+                        this_randomizer = torchvision.transforms.CenterCrop(
                             size=(h,w)
                         )
                 # configure normalizer


### PR DESCRIPTION
Hello, first of all, congratulation on this amazing work, it is really inspiring!

I am building on top of this repo for my next project, and I noticed a small bug that prevents to use CenterCrop when setting `random_crop: False` in the .yaml config file. The variable name was wrong, so it was getting overwritten a couple of lines later. 

This pull request should fix it, hope it helps!